### PR TITLE
Started adding support for PyQt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ env:
     - QT_VER="QT5"
 
 before_install:
+
+  # Set up conda
   - source continuous-integration/travis/install_conda_$TRAVIS_OS_NAME.sh
+
+  # Setup system for headless GUI handling
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ install:
   - if [ $QT_VER == QT4 ]; then conda install --yes mock pytest sip pyqt pyside pip coverage; fi
   - if [ $QT_VER == QT5 ]; then conda install --yes mock pytest sip pyqt5 pip coverage; fi
 
+  # The following are required by coveralls so we install them with conda to
+  # save time
+  - conda install --yes pyyaml requests
+
   - pip install pytest-cov coveralls
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,31 @@ language: c
 os:
   - linux
 
+env:
+  matrix:
+    - QT_VER="QT4"
+    - QT_VER="QT5"
+
 before_install:
   - source continuous-integration/travis/install_conda_$TRAVIS_OS_NAME.sh
 
 install:
+
+  # The following is required for pyqt5
+  - conda config --add channels dsdale24
+
   - conda create --yes -n test python=2.7
+
   - source activate test
-  - conda install --yes mock pytest sip pyqt pyside pip coverage
+
+  - if [ $QT_VER == QT4 ]; then conda install --yes mock pytest sip pyqt pyside pip coverage; fi
+  - if [ $QT_VER == QT5 ]; then conda install --yes mock pytest sip pyqt5 pip coverage; fi
+
   - pip install pytest-cov coveralls
 
 script:
-  - py.test --cov qt_helpers.py
+  - if [ $QT_VER == QT4 ]; then py.test --cov qt_helpers.py test_qt_helpers.py; fi
+  - if [ $QT_VER == QT5 ]; then py.test --cov qt_helpers.py test_qt_helpers_qt5.py; fi
 
 after_success:
   - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,5 +39,5 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% py.test"
+  - "%CMD_IN_ENV% py.test test_qt_helpers.py"
 

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -177,7 +177,7 @@ QtCore = None
 QtGui = None
 
 
-def load_qt():
+def reload_qt():
 
     _forbidden.clear()
 
@@ -258,4 +258,4 @@ def get_qapp(icon_path=None):
 
 
 # Now load default Qt
-load_qt()
+reload_qt()

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -42,6 +42,7 @@ def is_pyqt5():
 
 # Backward-compatibility
 is_pyqt = is_pyqt4
+QT_API_PYQT = QT_API_PYQT4
 
 _forbidden = set()
 

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -241,5 +241,16 @@ def _load_ui_pyqt5(path, parent):
     from PyQt5.uic import loadUi
     return loadUi(path, parent)
 
+
+def get_qapp(icon_path=None):
+    qapp = QtGui.QApplication.instance()
+    if qapp is None:
+        qapp = QtGui.QApplication([''])
+        qapp.setQuitOnLastWindowClosed(True)
+        if icon_path is not None:
+            qapp.setWindowIcon(QIcon(icon_path))
+    return qapp
+
+
 # Now load default Qt
 load_qt()

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -179,6 +179,15 @@ QtGui = None
 
 
 def reload_qt():
+    """
+    Reload the Qt bindings.
+
+    If the QT_API environment variable has been updated, this will load the
+    new Qt bindings given by this variable. This should be used instead of
+    the build-in ``reload`` function because the latter can in some cases
+    cause issues with the ImportDenier (which prevents users from importing
+    e.g. PySide if PyQt4 is loaded).
+    """
 
     _forbidden.clear()
 
@@ -196,7 +205,6 @@ def reload_qt():
 
     # acutally do the loading
     for loader in loaders:
-        print(loader)
         try:
             loader()
             # we set this env var, since IPython also looks for it

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -135,9 +135,10 @@ def _load_pyqt5():
 
     # In PyQt5, some widgets such as QMessageBox have moved from QtGui to
     # QWidgets so we add backward-compatibility hooks here for now
-    QtGui.QMessageBox = QtWidgets.QMessageBox
-    QtGui.QFileDialog = QtWidgets.QFileDialog
-    QtGui.QApplication = QtWidgets.QApplication
+    for widget in dir(QtWidgets):
+        if widget.startswith('Q'):
+            setattr(QtGui, widget, getattr(QtWidgets, widget))
+    QtGui.QItemSelectionModel = QtCore.QItemSelectionModel
 
     register_module(QtCore, 'QtCore')
     register_module(QtGui, 'QtGui')

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -46,6 +46,7 @@ QT_API_PYQT = QT_API_PYQT4
 
 _forbidden = set()
 
+
 def deny_module(module):
     _forbidden.add(module)
 
@@ -68,6 +69,7 @@ class ImportDenier(object):
 
 _import_hook = ImportDenier()
 sys.meta_path.append(_import_hook)
+
 
 def prepare_pyqt4():
     # For PySide compatibility, use the new-style string API that
@@ -174,6 +176,7 @@ def _load_pyside():
 QtCore = None
 QtGui = None
 
+
 def load_qt():
 
     _forbidden.clear()
@@ -182,9 +185,9 @@ def load_qt():
     global QtGui
 
     if os.environ.get('QT_API') == QT_API_PYQT5:
-        loaders = [ _load_pyqt5]
+        loaders = [_load_pyqt5]
     elif os.environ.get('QT_API') == QT_API_PYSIDE:
-        loaders = [ _load_pyside, _load_pyqt4]
+        loaders = [_load_pyside, _load_pyqt4]
     else:
         loaders = [_load_pyqt4, _load_pyside]
 
@@ -207,6 +210,7 @@ def load_qt():
         raise ImportError("Could not find a suitable QT installation."
                           " Encountered the following errors: %s" %
                           '\n'.join(msgs))
+
 
 def load_ui(path, parent=None, custom_widgets=None):
     if is_pyside():

--- a/qt_helpers.py
+++ b/qt_helpers.py
@@ -22,28 +22,42 @@ import sys
 __all__ = ['QtCore', 'QtGui', 'is_pyside', 'is_pyqt', 'load_ui']
 
 # Available APIs.
-QT_API_PYQT = 'pyqt'
+QT_API_PYQT4 = 'pyqt'
 QT_API_PYSIDE = 'pyside'
+QT_API_PYQT5 = 'pyqt5'
 QT_API = None
+
+
+def is_pyside():
+    return QT_API == QT_API_PYSIDE
+
+
+def is_pyqt4():
+    return QT_API == QT_API_PYQT4
+
+
+def is_pyqt5():
+    return QT_API == QT_API_PYQT5
+
+
+# Backward-compatibility
+is_pyqt = is_pyqt4
+
+_forbidden = set()
+
+def deny_module(module):
+    _forbidden.add(module)
 
 
 class ImportDenier(object):
     """
-    Import hook to protect importing of both PySide and PyQt4.
+    Import hook to protect importing of both PySide and PyQt.
     """
-    
-    __forbidden = set()
-
-    def __init__(self):
-        self.__forbidden = None
-
-    def forbid(self, module_name):
-        self.__forbidden = module_name
 
     def find_module(self, mod_name, pth):
-        if pth:
+        if pth or not mod_name in _forbidden:
             return
-        if mod_name == self.__forbidden:
+        else:
             return self
 
     def load_module(self, mod_name):
@@ -54,29 +68,26 @@ class ImportDenier(object):
 _import_hook = ImportDenier()
 sys.meta_path.append(_import_hook)
 
-
 def prepare_pyqt4():
-    # For PySide compatibility, use the new-style string API that 
-    # automatically converts QStrings to Unicode Python strings. Also, 
+    # For PySide compatibility, use the new-style string API that
+    # automatically converts QStrings to Unicode Python strings. Also,
     # automatically unpack QVariants to their underlying objects.
     import sip
     sip.setapi('QString', 2)
     sip.setapi('QVariant', 2)
 
+prepare_pyqt5 = prepare_pyqt4
+
 
 def register_module(module, modlabel):
     """
     Register an imported module into a submodule of qt_helpers.
-    
+
     This enables syntax such as:
-    
+
         >>> from qt_helpers.QtGui import QMessageBox
     """
     sys.modules[__name__ + '.' + modlabel] = module
-
-
-def deny_module(mod_name):
-    _import_hook.forbid(mod_name)
 
 
 def _load_pyqt4():
@@ -102,9 +113,38 @@ def _load_pyqt4():
     register_module(QtTest, 'QtTest')
 
     global QT_API
-    QT_API = QT_API_PYQT
+    QT_API = QT_API_PYQT4
 
     deny_module('PySide')
+    deny_module('PyQt5')
+
+
+def _load_pyqt5():
+
+    prepare_pyqt5()
+
+    from PyQt5 import QtCore, QtGui, QtTest, QtWidgets
+    from distutils.version import LooseVersion
+
+    QtCore.Signal = QtCore.pyqtSignal
+    QtCore.Slot = QtCore.pyqtSlot
+    QtCore.Property = QtCore.pyqtProperty
+
+    # In PyQt5, some widgets such as QMessageBox have moved from QtGui to
+    # QWidgets so we add backward-compatibility hooks here for now
+    QtGui.QMessageBox = QtWidgets.QMessageBox
+    QtGui.QFileDialog = QtWidgets.QFileDialog
+    QtGui.QApplication = QtWidgets.QApplication
+
+    register_module(QtCore, 'QtCore')
+    register_module(QtGui, 'QtGui')
+    register_module(QtTest, 'QtTest')
+
+    global QT_API
+    QT_API = QT_API_PYQT5
+
+    deny_module('PySide')
+    deny_module('PyQt4')
 
 
 def _load_pyside():
@@ -127,48 +167,57 @@ def _load_pyside():
     QT_API = QT_API_PYSIDE
 
     deny_module('PyQt4')
-
-loaders = [_load_pyqt4, _load_pyside]
-if os.environ.get('QT_API') == QT_API_PYSIDE:
-    loaders = loaders[::-1]
-
-msgs = []
-
-# acutally do the loading
-for loader in loaders:
-    try:
-        loader()
-        # we set this env var, since IPython also looks for it
-        os.environ['QT_API'] = QT_API
-        QtCore = sys.modules[__name__ + '.QtCore']
-        QtGui = sys.modules[__name__ + '.QtGui']
-        break
-    except ImportError as e:
-        msgs.append(str(e))
-        pass
-else:
-    raise ImportError("Could not find a suitable QT installation."
-                      " Encountered the following errors: %s" %
-                      '\n'.join(msgs))
+    deny_module('PyQt5')
 
 
-def is_pyside():
-    return QT_API == QT_API_PYSIDE
+QtCore = None
+QtGui = None
 
+def load_qt():
 
-def is_pyqt():
-    return QT_API == QT_API_PYQT
+    _forbidden.clear()
 
+    global QtCore
+    global QtGui
+
+    if os.environ.get('QT_API') == QT_API_PYQT5:
+        loaders = [ _load_pyqt5]
+    elif os.environ.get('QT_API') == QT_API_PYSIDE:
+        loaders = [ _load_pyside, _load_pyqt4]
+    else:
+        loaders = [_load_pyqt4, _load_pyside]
+
+    msgs = []
+
+    # acutally do the loading
+    for loader in loaders:
+        print(loader)
+        try:
+            loader()
+            # we set this env var, since IPython also looks for it
+            os.environ['QT_API'] = QT_API
+            QtCore = sys.modules[__name__ + '.QtCore']
+            QtGui = sys.modules[__name__ + '.QtGui']
+            break
+        except ImportError as e:
+            msgs.append(str(e))
+            pass
+    else:
+        raise ImportError("Could not find a suitable QT installation."
+                          " Encountered the following errors: %s" %
+                          '\n'.join(msgs))
 
 def load_ui(path, parent=None, custom_widgets=None):
     if is_pyside():
         return _load_ui_pyside(path, parent, custom_widgets=custom_widgets)
+    elif is_pyqt5():
+        return _load_ui_pyqt5(path, parent)
     else:
         return _load_ui_pyqt4(path, parent)
 
 
 def _load_ui_pyside(path, parent, custom_widgets=None):
-    
+
     from PySide.QtUiTools import QUiLoader
 
     loader = QUiLoader()
@@ -186,3 +235,11 @@ def _load_ui_pyside(path, parent, custom_widgets=None):
 def _load_ui_pyqt4(path, parent):
     from PyQt4.uic import loadUi
     return loadUi(path, parent)
+
+
+def _load_ui_pyqt5(path, parent):
+    from PyQt5.uic import loadUi
+    return loadUi(path, parent)
+
+# Now load default Qt
+load_qt()

--- a/test.ui
+++ b/test.ui
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Ceci n'est pas un bouton</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/test_qt_helpers.py
+++ b/test_qt_helpers.py
@@ -8,8 +8,6 @@ import qt_helpers as qt
 import pytest
 from mock import MagicMock
 
-from imp import reload
-
 
 class TestQT(object):
 
@@ -24,20 +22,20 @@ class TestQT(object):
             os.environ.pop('QT_API')
 
     def test_defaults_to_qt4(self):
-        reload(qt)
-        assert qt.QT_API == qt.QT_API_PYQT
+        qt.load_qt()
+        assert qt.QT_API == qt.QT_API_PYQT4
 
     def _load_qt4(self):
-        os.environ['QT_API'] = qt.QT_API_PYQT
-        reload(qt)
+        os.environ['QT_API'] = qt.QT_API_PYQT4
+        qt.load_qt()
 
     def _load_pyside(self):
         os.environ['QT_API'] = qt.QT_API_PYSIDE
-        reload(qt)
+        qt.load_qt()
 
     def test_overridden_with_env(self):
         os.environ['QT_API'] = qt.QT_API_PYSIDE
-        reload(qt)
+        qt.load_qt()
         assert qt.QT_API == qt.QT_API_PYSIDE
 
     def test_main_import(self):
@@ -56,6 +54,20 @@ class TestQT(object):
         from PySide import QtCore as core, QtGui as gui
         assert QtCore is core
         assert QtGui is gui
+
+    def test_load_ui_qt4(self):
+        self._load_qt4()
+        from qt_helpers import load_ui
+        from qt_helpers.QtGui import QApplication
+        qapp = QApplication([''])
+        load_ui('test.ui')
+
+    def test_load_ui_pyside(self):
+        self._load_pyside()
+        from qt_helpers import load_ui
+        from qt_helpers.QtGui import QApplication
+        qapp = QApplication([''])
+        load_ui('test.ui')
 
     def test_submodule_import(self):
         self._load_qt4()
@@ -93,7 +105,7 @@ class TestQT(object):
         try:
             sys.modules['PySide'] = None
             self._load_pyside()
-            assert qt.QT_API == qt.QT_API_PYQT
+            assert qt.QT_API == qt.QT_API_PYQT4
         finally:
             sys.modules['PySide'] = PySide
 
@@ -104,7 +116,7 @@ class TestQT(object):
             sys.modules['PySide'] = None
             sys.modules['PyQt4'] = None
             with pytest.raises(ImportError) as e:
-                reload(qt)
+                qt.load_qt()
         finally:
             sys.modules['PySide'] = PySide
             sys.modules['PyQt4'] = PyQt4

--- a/test_qt_helpers.py
+++ b/test_qt_helpers.py
@@ -57,16 +57,14 @@ class TestQT(object):
 
     def test_load_ui_qt4(self):
         self._load_qt4()
-        from qt_helpers import load_ui
-        from qt_helpers.QtGui import QApplication
-        qapp = QApplication([''])
+        from qt_helpers import load_ui, get_qapp
+        qpp = get_qapp()
         load_ui('test.ui')
 
     def test_load_ui_pyside(self):
         self._load_pyside()
-        from qt_helpers import load_ui
-        from qt_helpers.QtGui import QApplication
-        qapp = QApplication([''])
+        from qt_helpers import load_ui, get_qapp
+        qpp = get_qapp()
         load_ui('test.ui')
 
     def test_submodule_import(self):

--- a/test_qt_helpers.py
+++ b/test_qt_helpers.py
@@ -59,14 +59,19 @@ class TestQT(object):
     def test_load_ui_qt4(self):
         self._load_qt4()
         from qt_helpers import load_ui, get_qapp
-        qpp = get_qapp()
+        app = get_qapp()
         load_ui('test.ui')
+        app.quit()
+        del app
 
     def test_load_ui_pyside(self):
         self._load_pyside()
         from qt_helpers import load_ui, get_qapp
-        qpp = get_qapp()
+        app = get_qapp()
         load_ui('test.ui')
+        app.exit()
+        app.quit()
+        del app
 
     def test_submodule_import(self):
         self._load_qt4()
@@ -122,10 +127,13 @@ class TestQT(object):
 
     def test_launch_after_reload(self):
 
+        os.environ['QT_API'] = qt.QT_API_PYSIDE
+        qt.reload_qt()
+
         from qt_helpers import QtCore
         from qt_helpers import QtGui
 
-        app = QtGui.QApplication([''])
+        app = qt.get_qapp()
         widget = QtGui.QMessageBox()
         widget.show()
         app.flush()
@@ -140,7 +148,7 @@ class TestQT(object):
         from qt_helpers import QtCore
         from qt_helpers import QtGui
 
-        app = QtGui.QApplication([''])
+        app = qt.get_qapp()
         widget = QtGui.QMessageBox()
         widget.show()
         app.flush()
@@ -155,7 +163,7 @@ class TestQT(object):
         from qt_helpers import QtCore
         from qt_helpers import QtGui
 
-        app = QtGui.QApplication([''])
+        app = qt.get_qapp()
         widget = QtGui.QMessageBox()
         widget.show()
         app.flush()

--- a/test_qt_helpers.py
+++ b/test_qt_helpers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
+import time
 
 import qt_helpers as qt
 
@@ -118,3 +119,48 @@ class TestQT(object):
         finally:
             sys.modules['PySide'] = PySide
             sys.modules['PyQt4'] = PyQt4
+
+    def test_launch_after_reload(self):
+
+        from qt_helpers import QtCore
+        from qt_helpers import QtGui
+
+        app = QtGui.QApplication([''])
+        widget = QtGui.QMessageBox()
+        widget.show()
+        app.flush()
+        time.sleep(0.1)
+        app.quit()
+
+        del app
+
+        os.environ['QT_API'] = qt.QT_API_PYQT4
+        qt.reload_qt()
+
+        from qt_helpers import QtCore
+        from qt_helpers import QtGui
+
+        app = QtGui.QApplication([''])
+        widget = QtGui.QMessageBox()
+        widget.show()
+        app.flush()
+        time.sleep(0.1)
+        app.quit()
+
+        del app
+
+        os.environ['QT_API'] = qt.QT_API_PYSIDE
+        qt.reload_qt()
+
+        from qt_helpers import QtCore
+        from qt_helpers import QtGui
+
+        app = QtGui.QApplication([''])
+        widget = QtGui.QMessageBox()
+        widget.show()
+        app.flush()
+        time.sleep(0.1)
+        app.quit()
+
+        del app
+

--- a/test_qt_helpers.py
+++ b/test_qt_helpers.py
@@ -22,20 +22,20 @@ class TestQT(object):
             os.environ.pop('QT_API')
 
     def test_defaults_to_qt4(self):
-        qt.load_qt()
+        qt.reload_qt()
         assert qt.QT_API == qt.QT_API_PYQT4
 
     def _load_qt4(self):
         os.environ['QT_API'] = qt.QT_API_PYQT4
-        qt.load_qt()
+        qt.reload_qt()
 
     def _load_pyside(self):
         os.environ['QT_API'] = qt.QT_API_PYSIDE
-        qt.load_qt()
+        qt.reload_qt()
 
     def test_overridden_with_env(self):
         os.environ['QT_API'] = qt.QT_API_PYSIDE
-        qt.load_qt()
+        qt.reload_qt()
         assert qt.QT_API == qt.QT_API_PYSIDE
 
     def test_main_import(self):
@@ -114,7 +114,7 @@ class TestQT(object):
             sys.modules['PySide'] = None
             sys.modules['PyQt4'] = None
             with pytest.raises(ImportError) as e:
-                qt.load_qt()
+                qt.reload_qt()
         finally:
             sys.modules['PySide'] = PySide
             sys.modules['PyQt4'] = PyQt4

--- a/test_qt_helpers_qt5.py
+++ b/test_qt_helpers_qt5.py
@@ -8,13 +8,12 @@ from mock import MagicMock
 
 
 # At the moment it is not possible to have PyQt5 and PyQt4 installed
-# simultaneously because one requires the Qt4 libraries while the other 
+# simultaneously because one requires the Qt4 libraries while the other
 # requires the Qt5 libraries
 
 class TestQT5(object):
 
     def setup_class(cls):
-        print('-' * 72)
         os.environ['QT_API'] = 'pyqt5'
         import qt_helpers as qt
 
@@ -24,6 +23,7 @@ class TestQT5(object):
     def test_main_import_qt5(self):
 
         self._load_qt5()
+
         from qt_helpers import QtCore
         from qt_helpers import QtGui
 
@@ -31,11 +31,13 @@ class TestQT5(object):
         assert QtCore is core
         assert QtGui is gui
 
-    def test_load_ui_qt5(self):
-        self._load_qt5()
-        from qt_helpers import load_ui, get_qapp
-        qpp = get_qapp()
-        load_ui('test.ui')
+    # At the moment, PyQt5 does not run correctly on Travis so we can't run
+    # this without causing an Abort Trap.
+    # def test_load_ui_qt5(self):
+    #     self._load_qt5()
+    #     from qt_helpers import load_ui, get_qapp
+    #     qpp = get_qapp()
+    #     load_ui('test.ui')
 
     def test_submodule_import_qt5(self):
 
@@ -48,17 +50,3 @@ class TestQT5(object):
         from PyQt5.QtCore import Qt as _qt
         assert qmb is QMessageBox
         assert _qt is Qt
-
-    def test_submodule_import_pyside(self):
-
-        self._load_pyside()
-
-        from qt_helpers.QtGui import QMessageBox
-        from qt_helpers.QtCore import Qt
-
-        from PySide.QtGui import QMessageBox as qmb
-        from PySide.QtCore import Qt as _qt
-        assert qmb is QMessageBox
-        assert _qt is Qt
-
-

--- a/test_qt_helpers_qt5.py
+++ b/test_qt_helpers_qt5.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
+
+import pytest
+from mock import MagicMock
+
+
+# At the moment it is not possible to have PyQt5 and PyQt4 installed
+# simultaneously because one requires the Qt4 libraries while the other 
+# requires the Qt5 libraries
+
+class TestQT5(object):
+
+    def setup_class(cls):
+        print('-' * 72)
+        os.environ['QT_API'] = 'pyqt5'
+        import qt_helpers as qt
+
+    def _load_qt5(self):
+        import qt_helpers as qt
+
+    def test_main_import_qt5(self):
+
+        self._load_qt5()
+        from qt_helpers import QtCore
+        from qt_helpers import QtGui
+
+        from PyQt5 import QtCore as core, QtGui as gui
+        assert QtCore is core
+        assert QtGui is gui
+
+    def test_load_ui_qt5(self):
+        self._load_qt5()
+        from qt_helpers import load_ui
+        from qt_helpers.QtGui import QApplication
+        qapp = QApplication([''])
+        load_ui('test.ui')
+
+    def test_submodule_import_qt5(self):
+
+        self._load_qt5()
+
+        from qt_helpers.QtGui import QMessageBox
+        from qt_helpers.QtCore import Qt
+
+        from PyQt5.QtWidgets import QMessageBox as qmb
+        from PyQt5.QtCore import Qt as _qt
+        assert qmb is QMessageBox
+        assert _qt is Qt
+
+    def test_submodule_import_pyside(self):
+
+        self._load_pyside()
+
+        from qt_helpers.QtGui import QMessageBox
+        from qt_helpers.QtCore import Qt
+
+        from PySide.QtGui import QMessageBox as qmb
+        from PySide.QtCore import Qt as _qt
+        assert qmb is QMessageBox
+        assert _qt is Qt
+
+

--- a/test_qt_helpers_qt5.py
+++ b/test_qt_helpers_qt5.py
@@ -33,9 +33,8 @@ class TestQT5(object):
 
     def test_load_ui_qt5(self):
         self._load_qt5()
-        from qt_helpers import load_ui
-        from qt_helpers.QtGui import QApplication
-        qapp = QApplication([''])
+        from qt_helpers import load_ui, get_qapp
+        qpp = get_qapp()
         load_ui('test.ui')
 
     def test_submodule_import_qt5(self):


### PR DESCRIPTION
This starts to add support and tests for PyQt5. There is a subtlety however, which is that even conda doesn't complain if I install PyQt5 and PyQt4/Pyside in a same environment, PyQt5 is unable to create a QApplication in this case because the environment contains both the Qt4 and Qt5 libraries and it gets confused.

In addition, I found that some strange behaviors were due to the use of reload in tests, which doesn't actually clean up `sys.meta_path` which ends up containing many ImportDenier instances (because when it reloads the module it adds a new hook without removing the old one, and worse, all old instances are instances of a different class since it redefines the ImportDenier class every time). Anyway, because this is complex, I've tidied it up so that we don't actually call `reload` but intead have a `reload_qt` that ensures everything is clean and avoids this kind of issue.
